### PR TITLE
Add functions from echotest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,9 +13,18 @@
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
+[[projects]]
+  branch = "master"
+  name = "github.com/teamwork/utils"
+  packages = [
+    "jsonutil",
+    "stringutil"
+  ]
+  revision = "25cfdf9788fd470f3d664452bfc40ea3750618bb"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "916990b445ffe6c07389526896c11ea5cdf065b0015a986b000330569340ce1e"
+  inputs-digest = "00a209cf6fc367c3b2f5e0b2fcd5f6b18496e6ea6f5f56510b6f2d22b8b1943d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCode(t *testing.T) {
+	Code(t, &httptest.ResponseRecorder{Code: 200}, 200)
+
+	// TODO: how to test that t.Fatalf() was called?
+	//TestCode(t, &httptest.ResponseRecorder{Code: 200}, 201)
+}


### PR DESCRIPTION
This adds some non-echo specific functions from Desk's `echotest`
package. All of these can be used either with regular `net/http` tests
or `echo` tests.