### PR TITLE
Add pointer helpers

### DIFF
--- a/test.go
+++ b/test.go
@@ -135,3 +135,9 @@ func R(t *testing.T) {
 		t.Fatalf("panic recover: %v", r)
 	}
 }
+
+// SP makes a new String Pointer.
+func SP(s string) *string { return &s }
+
+// I64P makes a new Int64 Pointer.
+func I64P(i int64) *int64 { return &i }


### PR DESCRIPTION
This is useful in quite a few test cases. for example:

	{Installation{Domain: "foo"}, []string{"foo"}},
	{Installation{Domain: "foo", AltDomain: "bar"}, []string{"foo", "bar"}},
	{Installation{Domain: "foo", AltDomain2: "bar"}, []string{"foo", "bar"}},
	{Installation{Domain: "foo", AltDomain: "bar", AltDomain2: "fbar"}, []string{"foo", "bar", "fbar"}},

AltDomain and `AltDomain2` are `*string`. There is no easy way to do
this other than the clumsy:

	bar := "bar"
	barp := &bar

	{Installation{Domain: "foo", AltDomain: barp}, []string{"foo", "bar"}},

With this helper, this becomes the much easier to read:

	{Installation{Domain: "foo"}, []string{"foo"}},
	{Installation{Domain: "foo", AltDomain: test.SP("bar")}, []string{"foo", "bar"}},
	{Installation{Domain: "foo", AltDomain2: test.SP("bar")}, []string{"foo", "bar"}},
	{Installation{
		Domain: "foo", AltDomain: test.SP("bar"), AltDomain2: test.SP("fbar")},
		[]string{"foo", "bar", "fbar"}},

I've had some similar issues with int64 pointers as well for IDs, so
adding that as well. Other types can be added as needed, but I haven't
needed them yet.